### PR TITLE
Use OpenLayers v3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deploy": "npm run build && gh-pages --dist build/openlayers-workshop"
   },
   "dependencies": {
-    "openlayers": "https://github.com/openlayers/ol3/tarball/4dddf4c3d97ee3453b31dd3057937621e7ed7698"
+    "openlayers": "3.9.0"
   },
   "devDependencies": {
     "gh-pages": "^0.4.0",

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,6 @@
     "start": "node serve.js"
   },
   "dependencies": {
-    "openlayers": "https://github.com/openlayers/ol3/tarball/4dddf4c3d97ee3453b31dd3057937621e7ed7698"
+    "openlayers": "3.9.0"
   }
 }


### PR DESCRIPTION
This PR updates the workshop to use OpenLayers v3.9.0. I'll create a `v3.9.0` tag when this is merged, and I'll update the hosted version of the workshop.

Fixes #35.