### PR TITLE
Update OpenLayers to v3.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy": "npm run build && gh-pages --dist build/openlayers-workshop"
   },
   "dependencies": {
-    "openlayers": "3.14.2"
+    "openlayers": "3.16.0"
   },
   "devDependencies": {
     "gh-pages": "0.11.0",

--- a/src/en/custom-builds/create.md
+++ b/src/en/custom-builds/create.md
@@ -117,8 +117,10 @@ the [last chapter](../vector/style.md).
         "*"
       ],
       "jscomp_off": [
-        "useOfGoogBase",
-        "lintChecks"
+        "analyzerChecks",
+        "lintChecks",
+        "unnecessaryCasts",
+        "useOfGoogBase"
       ],
       "extra_annotation_name": [
         "api", "observable"

--- a/src/en/ol-custom.json
+++ b/src/en/ol-custom.json
@@ -39,8 +39,10 @@
       "*"
     ],
     "jscomp_off": [
-      "useOfGoogBase",
-      "lintChecks"
+      "analyzerChecks",
+      "lintChecks",
+      "unnecessaryCasts",
+      "useOfGoogBase"
     ],
     "extra_annotation_name": [
       "api", "observable"

--- a/src/en/package.json
+++ b/src/en/package.json
@@ -16,6 +16,6 @@
     "start": "node serve.js"
   },
   "dependencies": {
-    "openlayers": "3.14.2"
+    "openlayers": "3.16.0"
   }
 }


### PR DESCRIPTION
This updates the wokshop to use OpenLayers v3.16.0. The only chapter that needed adjustment was the custom builds one.

I'll gladly rebase this if #50 gets merged beforehand.

Please review.

Fixes #47