### PR TITLE
Use OpenLayers v3.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deploy": "npm run build && gh-pages --dist build/openlayers-workshop"
   },
   "dependencies": {
-    "openlayers": "3.17.1"
+    "openlayers": "3.16.0"
   },
   "devDependencies": {
     "gh-pages": "0.11.0",

--- a/src/en/package.json
+++ b/src/en/package.json
@@ -16,6 +16,6 @@
     "start": "node serve.js"
   },
   "dependencies": {
-    "openlayers": "3.17.1"
+    "openlayers": "3.16.0"
   }
 }

--- a/src/fr/package.json
+++ b/src/fr/package.json
@@ -16,6 +16,6 @@
     "start": "node serve.js"
   },
   "dependencies": {
-    "openlayers": "3.17.1"
+    "openlayers": "3.16.0"
   }
 }


### PR DESCRIPTION
This effectively reverts ddd6922f573879f6bdc253cef26cc0322a96a216 (from #55) for the main `package.json` and the `en`-variant.

Additionally the `fr`-variant is changed to also use OpenLayers v3.16.0.

See also #56, especially https://github.com/openlayers/workshop/issues/56#issuecomment-240119086

Please review.