### PR TITLE
Add a script to test whether custom builds work

### DIFF
--- a/ol-custom.json
+++ b/ol-custom.json
@@ -1,0 +1,55 @@
+{
+  "exports": [
+    "ol.Map",
+    "ol.View",
+    "ol.format.KML",
+    "ol.layer.Tile",
+    "ol.layer.Vector",
+    "ol.proj.fromLonLat",
+    "ol.source.OSM",
+    "ol.source.Vector",
+    "ol.style.Fill",
+    "ol.style.Stroke",
+    "ol.style.Style",
+    "ol.style.Text"
+  ],
+  "jvm": [],
+  "umd": true,
+  "compile": {
+    "externs": [
+      "externs/bingmaps.js",
+      "externs/closure-compiler.js",
+      "externs/esrijson.js",
+      "externs/geojson.js",
+      "externs/oli.js",
+      "externs/olx.js",
+      "externs/proj4js.js",
+      "externs/tilejson.js",
+      "externs/topojson.js"
+    ],
+    "define": [
+      "goog.dom.ASSUME_STANDARDS_MODE=true",
+      "goog.DEBUG=false",
+      "ol.ENABLE_DOM=false",
+      "ol.ENABLE_WEBGL=false",
+      "ol.ENABLE_PROJ4JS=false",
+      "ol.ENABLE_IMAGE=false"
+    ],
+    "jscomp_error": [
+      "*"
+    ],
+    "jscomp_off": [
+      "analyzerChecks",
+      "lintChecks",
+      "unnecessaryCasts",
+      "useOfGoogBase"
+    ],
+    "extra_annotation_name": [
+      "api", "observable"
+    ],
+    "compilation_level": "ADVANCED",
+    "warning_level": "VERBOSE",
+    "use_types_for_optimization": true,
+    "manage_closure_dependencies": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "homepage": "https://github.com/openlayers/workshop#readme",
   "scripts": {
     "start": "mkdir -p src/_book && cp node_modules/openlayers/css/ol.css src/ && npm run doc:serve",
-    "test": "npm run doc:build",
+    "test": "npm run doc:build && npm run test:custom-build-chapter",
+    "test:custom-build": "node node_modules/openlayers/tasks/build.js ol-custom.json ol-custom.js && rm ol-custom.js",
     "clean": "rm -rf src/_book build",
     "postinstall": "gitbook install src",
     "doc:serve": "gitbook serve src",


### PR DESCRIPTION
This script executes the command we use inside of the workshop with a build configuration also from the workshop. It should complete without errors, otherwise it hints that either the build configuration isn't correct or the OpenLayers sources have some issues.

This hopefully prevents commits like ddd6922f573879f6bdc253cef26cc0322a96a216 (already reverted with a64723ba4e51e08092ae76fb4724c2a4f64b306d).

Please review.