### PR TITLE
Configure Travis CI so upload of files can work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ deploy:
   api_key:
     secure: ag2ObhNaZYbULIABDARbHyvqk9DChYg6j6HZUmocdfM4Go/MF/OckpR0VntiMKpv+eQ8vdmTyRWVcW4Y/B+AOkMs/fhRs4rYOLq7BXWyLLbcvNaXP+3n6HDB/RZBPcNCYdQUo+oDDOyk7W9vF5T3o4aKlXFRLQIVQgABrwEQC1I=
   file:
-    - build/openlayers-workshop-en.zip
-    - build/openlayers-workshop-fr.zip
+    - openlayers-workshop-en.zip
+    - openlayers-workshop-fr.zip
   on:
     repo: openlayers/workshop
     tags: true


### PR DESCRIPTION
<del>
We need to explicitly stop Travis from running `git stash --all` in the `deploy` phase as that command would remove our zip files from the build phase.

See https://docs.travis-ci.com/user/deployment/#Uploading-Files for more background information.
</del>

We were referencing the zips from the wrong location, this PR attempts to fix this.