### PR TITLE
Update gh-pages dependency to v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "openlayers": "3.16.0"
   },
   "devDependencies": {
-    "gh-pages": "0.11.0",
+    "gh-pages": "0.12.0",
     "gitbook-cli": "2.3.0"
   }
 }


### PR DESCRIPTION
This PR suggests to update the `gh-pages` module to `0.12.0`.

Here is the [diff of `gh-pages`](https://github.com/tschaub/gh-pages/compare/v0.11.0...v0.12.0), here [the changelog](https://github.com/tschaub/gh-pages/blob/master/changelog.md#v0120).

Please review.