### PR TITLE
Update to latest OpenLayers v4.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,20 @@
-/build/
-/node_modules/
-/src/_book/
-/src/ol.css
+# ignore installed dependencies from node
+node_modules/
+
+# ignore complete build directory (pdfs etc)
+build/
+
+# from this folder gitbook serves its content
+src/_book
+
+# copied when the dev server runs (in both language folders)
+ol.css
+
+# from custom builds chapter, *.json and *.js (in both language folders)
+ol-custom.js*
+
+# the main example file (in both language folders)
+map.html
+
 openlayers-workshop-en.zip
 openlayers-workshop-fr.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - '0.12'
+  - 6
+script:
+  - npm test
+  - node node_modules/openlayers/tasks/build.js src/en/data/build-config/vector-chapter.json custom-build.js &&  stat -c "%n %s bytes" custom-build.js && rm custom-build.js
 cache:
   directories:
     - node_modules

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deploy": "npm run build && gh-pages --dist build/openlayers-workshop"
   },
   "dependencies": {
-    "openlayers": "3.16.0"
+    "openlayers": "4.0.1"
   },
   "devDependencies": {
     "gh-pages": "0.12.0",

--- a/src/book.json
+++ b/src/book.json
@@ -9,7 +9,8 @@
     }
   },
   "plugins": [
-    "image-captions"
+    "image-captions",
+    "include"
   ],
   "pluginsConfig": {
     "image-captions": {

--- a/src/en/custom-builds/create.md
+++ b/src/en/custom-builds/create.md
@@ -75,63 +75,9 @@ the [last chapter](../vector/style.md).
 
 2. Create a build configuration file `ol-custom.json` for that map:
 
-  ```json
-  {
-    "exports": [
-      "ol.Map",
-      "ol.View",
-      "ol.format.KML",
-      "ol.layer.Tile",
-      "ol.layer.Vector",
-      "ol.proj.fromLonLat",
-      "ol.source.OSM",
-      "ol.source.Vector",
-      "ol.style.Fill",
-      "ol.style.Stroke",
-      "ol.style.Style",
-      "ol.style.Text"
-    ],
-    "jvm": [],
-    "umd": true,
-    "compile": {
-      "externs": [
-        "externs/bingmaps.js",
-        "externs/closure-compiler.js",
-        "externs/esrijson.js",
-        "externs/geojson.js",
-        "externs/oli.js",
-        "externs/olx.js",
-        "externs/proj4js.js",
-        "externs/tilejson.js",
-        "externs/topojson.js"
-      ],
-      "define": [
-        "goog.dom.ASSUME_STANDARDS_MODE=true",
-        "goog.DEBUG=false",
-        "ol.ENABLE_DOM=false",
-        "ol.ENABLE_WEBGL=false",
-        "ol.ENABLE_PROJ4JS=false",
-        "ol.ENABLE_IMAGE=false"
-      ],
-      "jscomp_error": [
-        "*"
-      ],
-      "jscomp_off": [
-        "analyzerChecks",
-        "lintChecks",
-        "unnecessaryCasts",
-        "useOfGoogBase"
-      ],
-      "extra_annotation_name": [
-        "api", "observable"
-      ],
-      "compilation_level": "ADVANCED",
-      "warning_level": "VERBOSE",
-      "use_types_for_optimization": true,
-      "manage_closure_dependencies": true
-    }
-  }
-  ```
+```json
+!INCLUDE "../data/build-config/vector-chapter.json"
+```
 
 3. Create the custom build using `OpenLayers`'s `build.js` Node script:
 

--- a/src/en/data/build-config/vector-chapter.json
+++ b/src/en/data/build-config/vector-chapter.json
@@ -1,0 +1,53 @@
+{
+  "exports": [
+    "ol.Map",
+    "ol.View",
+    "ol.format.KML",
+    "ol.layer.Tile",
+    "ol.layer.Vector",
+    "ol.proj.fromLonLat",
+    "ol.source.OSM",
+    "ol.source.Vector",
+    "ol.style.Fill",
+    "ol.style.Stroke",
+    "ol.style.Style",
+    "ol.style.Text"
+  ],
+  "jvm": [],
+  "umd": true,
+  "compile": {
+    "externs": [
+      "externs/bingmaps.js",
+      "externs/cartodb.js",
+      "externs/closure-compiler.js",
+      "externs/esrijson.js",
+      "externs/geojson.js",
+      "externs/oli.js",
+      "externs/olx.js",
+      "externs/proj4js.js",
+      "externs/tilejson.js",
+      "externs/topojson.js"
+    ],
+    "define": [
+      "goog.DEBUG=false",
+      "ol.ENABLE_WEBGL=false",
+      "ol.ENABLE_PROJ4JS=false"
+    ],
+    "jscomp_error": [
+      "*"
+    ],
+    "jscomp_off": [
+      "analyzerChecks",
+      "lintChecks",
+      "unnecessaryCasts",
+      "useOfGoogBase"
+    ],
+    "extra_annotation_name": [
+      "api", "observable"
+    ],
+    "compilation_level": "ADVANCED",
+    "warning_level": "VERBOSE",
+    "use_types_for_optimization": true,
+    "manage_closure_dependencies": true
+  }
+}

--- a/src/en/package.json
+++ b/src/en/package.json
@@ -16,6 +16,6 @@
     "start": "node serve.js"
   },
   "dependencies": {
-    "openlayers": "3.16.0"
+    "openlayers": "4.0.1"
   }
 }


### PR DESCRIPTION
This PR suggests to update the engluish version of the workshop to OpenLayers 4.0.1.

The main changes herein are:
* upgrade to v4.0.1
* read the build config from a file and include it in the `*.md` file
* adjust the build config: @fredj (or anyone else) I'd love to get your feedback on the updated config, I am by no means an expert
* adjust CI
  * use Node 6
  * try to actually build using the `custom-build-config`

A future update might introduce the alternative way of using OpenLayers, but is not included herein.

Please review.