### PR TITLE
Use a reliable GeoServer instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ ol.css
 ol-custom.js*
 
 # the main example file (in both language folders)
-map.html
+src/*/map.html
 
 openlayers-workshop-en.zip
 openlayers-workshop-fr.zip

--- a/src/en/basics/dissect.md
+++ b/src/en/basics/dissect.md
@@ -45,8 +45,8 @@ The next step in generating your map is to include some initialization code. In 
       layers: [
         new ol.layer.Tile({
           source: new ol.source.TileWMS({
-            url: 'http://demo.opengeo.org/geoserver/wms',
-            params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+            url: 'https://ahocevar.com/geoserver/wms',
+            params: {LAYERS: 'nasa:bluemarble', TILED: true}
           })
         })
       ],
@@ -79,8 +79,8 @@ The layers config creates a layer to be displayed in our map:
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileWMS({
-        url: 'http://demo.opengeo.org/geoserver/wms',
-        params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+        url: 'https://ahocevar.com/geoserver/wms',
+        params: {LAYERS: 'nasa:bluemarble', TILED: true}
       })
     })
   ],

--- a/src/en/basics/map.md
+++ b/src/en/basics/map.md
@@ -30,8 +30,8 @@ Let's take a look at a fully working example of an OpenLayers map.
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
-              params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+              url: 'https://ahocevar.com/geoserver/wms',
+              params: {LAYERS: 'nasa:bluemarble', TILED: true}
             })
           })
         ],

--- a/src/en/controls/draw.md
+++ b/src/en/controls/draw.md
@@ -41,8 +41,8 @@ New features can be drawn by using an `ol.interaction.Draw`. A draw interaction 
               new ol.layer.Tile({
                 title: 'Global Imagery',
                 source: new ol.source.TileWMS({
-                  url: 'http://demo.opengeo.org/geoserver/wms',
-                  params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+                  url: 'https://ahocevar.com/geoserver/wms',
+                  params: {LAYERS: 'nasa:bluemarble', TILED: true}
                 })
               }),
               new ol.layer.Vector({

--- a/src/en/controls/modify.md
+++ b/src/en/controls/modify.md
@@ -54,8 +54,8 @@ Modifying features works by using an `ol.interaction.Select` in combination with
             new ol.layer.Tile({
               title: 'Global Imagery',
               source: new ol.source.TileWMS({
-                url: 'http://demo.opengeo.org/geoserver/wms',
-                params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+                url: 'https://ahocevar.com/geoserver/wms',
+                params: {LAYERS: 'nasa:bluemarble', TILED: true}
               })
             }),
             new ol.layer.Vector({

--- a/src/en/controls/select.md
+++ b/src/en/controls/select.md
@@ -49,8 +49,8 @@ The previous example demonstrated the use of an `ol.control.Control` on the map.
             new ol.layer.Tile({
               title: 'Global Imagery',
               source: new ol.source.TileWMS({
-                url: 'http://demo.opengeo.org/geoserver/wms',
-                params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+                url: 'https://ahocevar.com/geoserver/wms',
+                params: {LAYERS: 'nasa:bluemarble', TILED: true}
               })
             }),
             new ol.layer.Vector({

--- a/src/en/examples/map.html
+++ b/src/en/examples/map.html
@@ -21,7 +21,7 @@
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
+              url: 'https://ahocevar.com/geoserver/wms',
               params: {'LAYERS': 'nasa:bluemarble', 'VERSION': '1.1.1'}
             })
           })

--- a/src/en/examples/scaleline.html
+++ b/src/en/examples/scaleline.html
@@ -35,7 +35,7 @@
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
+              url: 'https://ahocevar.com/geoserver/wms',
               params: {'LAYERS': 'nasa:bluemarble', 'VERSION': '1.1.1'}
             })
           })

--- a/src/en/examples/select.html
+++ b/src/en/examples/select.html
@@ -36,7 +36,7 @@
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
+              url: 'https://ahocevar.com/geoserver/wms',
               params: {'LAYERS': 'nasa:bluemarble', 'VERSION': '1.1.1'}
             })
           }),

--- a/src/en/examples/vector.html
+++ b/src/en/examples/vector.html
@@ -30,7 +30,7 @@
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
+              url: 'https://ahocevar.com/geoserver/wms',
               params: {'LAYERS': 'nasa:bluemarble', 'VERSION': '1.1.1'}
             })
           }),

--- a/src/en/layers/imagevector.md
+++ b/src/en/layers/imagevector.md
@@ -34,8 +34,8 @@ Let's go back to the vector layer example to get earthquake data on top of a wor
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
-              params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+              url: 'https://ahocevar.com/geoserver/wms',
+              params: {LAYERS: 'nasa:bluemarble', TILED: true}
             })
           }),
           new ol.layer.Vector({

--- a/src/en/layers/vector.md
+++ b/src/en/layers/vector.md
@@ -30,8 +30,8 @@ Let's go back to the WMS example to get a basic world map.  We'll add some featu
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
-              params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+              url: 'https://ahocevar.com/geoserver/wms',
+              params: {LAYERS: 'nasa:bluemarble', TILED: true}
             })
           })
         ],

--- a/src/en/layers/wms.md
+++ b/src/en/layers/wms.md
@@ -35,8 +35,8 @@ Let's take a look at the following code:
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
-              params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+              url: 'https://ahocevar.com/geoserver/wms',
+              params: {LAYERS: 'nasa:bluemarble', TILED: true}
             })
           })
         ],
@@ -70,15 +70,15 @@ In OpenLayers there is a separation between layers and sources, whereas in OpenL
 ## The ol.source.TileWMS Constructor
 
 The `ol.source.TileWMS` constructor has a single argument which is defined by: http://openlayers.org/en/master/apidoc/ol.source.TileWMS.html.
-The url is the online resource of the WMS service, and params is an object literal with the parameter names and their values. Since the default WMS version is 1.3.0 now in OpenLayers, you might need to provide a lower version in the params if your WMS does not support WMS 1.3.0.
+The url is the online resource of the WMS service, and params is an object literal with the parameter names and their values. Only the `LAYERS` param is required. In this example, we add `TILED: true`, a GeoServer specific extension for better caching of tiled WMS layers.
 
 ```js
   layers: [
     new ol.layer.Tile({
       title: 'Global Imagery',
       source: new ol.source.TileWMS({
-        url: 'http://demo.opengeo.org/geoserver/wms',
-        params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+        url: 'https://ahocevar.com/geoserver/wms',
+        params: {LAYERS: 'nasa:bluemarble', TILED: true}
       })
     })
   ]
@@ -94,8 +94,8 @@ The url is the online resource of the WMS service, and params is an object liter
     new ol.layer.Tile({
       title: 'Global Imagery',
       source: new ol.source.TileWMS({
-        url: 'http://demo.opengeo.org/geoserver/wms',
-        params: {LAYERS: 'ne:NE1_HR_LC_SR_W_DR', VERSION: '1.1.1'}
+        url: 'https://ahocevar.com/geoserver/wms',
+        params: {LAYERS: 'ne:NE1_HR_LC_SR_W_DR', TILED: true}
       })
     })
   ```

--- a/src/fr/basics/dissect.md
+++ b/src/fr/basics/dissect.md
@@ -45,8 +45,8 @@ La prochaine étape dans la génération de votre carte est d'inclure un peu de 
       layers: [
         new ol.layer.Tile({
           source: new ol.source.TileWMS({
-            url: 'http://demo.opengeo.org/geoserver/wms',
-            params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+            url: 'https://ahocevar.com/geoserver/wms',
+            params: {LAYERS: 'nasa:bluemarble', TILED: true}
           })
         })
       ],
@@ -79,8 +79,8 @@ La configuration de couches créé une couche qui doit être affichée dans notr
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileWMS({
-        url: 'http://demo.opengeo.org/geoserver/wms',
-        params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+        url: 'https://ahocevar.com/geoserver/wms',
+        params: {LAYERS: 'nasa:bluemarble', TILED: true}
       })
     })
   ],

--- a/src/fr/basics/map.md
+++ b/src/fr/basics/map.md
@@ -30,8 +30,8 @@ Jetons un oeil à un exemple pleinement fonctionnel d'une carte OpenLayers.
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
-              params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+              url: 'https://ahocevar.com/geoserver/wms',
+              params: {LAYERS: 'nasa:bluemarble', TILED: true}
             })
           })
         ],

--- a/src/fr/controls/draw.md
+++ b/src/fr/controls/draw.md
@@ -41,8 +41,8 @@ De nouveaux objets géographiques peuvent être dessinés en utilisant une `ol.i
               new ol.layer.Tile({
                 title: 'Global Imagery',
                 source: new ol.source.TileWMS({
-                  url: 'http://demo.opengeo.org/geoserver/wms',
-                  params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+                  url: 'https://ahocevar.com/geoserver/wms',
+                  params: {LAYERS: 'nasa:bluemarble', TILED: true}
                 })
               }),
               new ol.layer.Vector({

--- a/src/fr/controls/modify.md
+++ b/src/fr/controls/modify.md
@@ -54,8 +54,8 @@ La modification des objets géographiques fonctionne en utilisant une `ol.intera
             new ol.layer.Tile({
               title: 'Global Imagery',
               source: new ol.source.TileWMS({
-                url: 'http://demo.opengeo.org/geoserver/wms',
-                params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+                url: 'https://ahocevar.com/geoserver/wms',
+                params: {LAYERS: 'nasa:bluemarble', TILED: true}
               })
             }),
             new ol.layer.Vector({

--- a/src/fr/controls/select.md
+++ b/src/fr/controls/select.md
@@ -49,8 +49,8 @@ L'exemple précédent faisait la démonstration de l'utilisation d'un `ol.contro
             new ol.layer.Tile({
               title: 'Global Imagery',
               source: new ol.source.TileWMS({
-                url: 'http://demo.opengeo.org/geoserver/wms',
-                params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+                url: 'https://ahocevar.com/geoserver/wms',
+                params: {LAYERS: 'nasa:bluemarble', TILED: true}
               })
             }),
             new ol.layer.Vector({

--- a/src/fr/examples/scaleline.html
+++ b/src/fr/examples/scaleline.html
@@ -35,7 +35,7 @@
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
+              url: 'https://ahocevar.com/geoserver/wms',
               params: {'LAYERS': 'nasa:bluemarble', 'VERSION': '1.1.1'}
             })
           })

--- a/src/fr/examples/select.html
+++ b/src/fr/examples/select.html
@@ -36,7 +36,7 @@
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
+              url: 'https://ahocevar.com/geoserver/wms',
               params: {'LAYERS': 'nasa:bluemarble', 'VERSION': '1.1.1'}
             })
           }),

--- a/src/fr/examples/vector.html
+++ b/src/fr/examples/vector.html
@@ -30,7 +30,7 @@
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
+              url: 'https://ahocevar.com/geoserver/wms',
               params: {'LAYERS': 'nasa:bluemarble', 'VERSION': '1.1.1'}
             })
           }),

--- a/src/fr/layers/imagevector.md
+++ b/src/fr/layers/imagevector.md
@@ -34,8 +34,8 @@ Revenons à l'exemple de couche vecteur pour avoir les données des tremblements
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
-              params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+              url: 'https://ahocevar.com/geoserver/wms',
+              params: {LAYERS: 'nasa:bluemarble', TILED: true}
             })
           }),
           new ol.layer.Vector({

--- a/src/fr/layers/vector.md
+++ b/src/fr/layers/vector.md
@@ -30,8 +30,8 @@ Revenons à l'exemple WMS pour avoir une carte du monde basique.  Nous allons aj
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
-              params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+              url: 'https://ahocevar.com/geoserver/wms',
+              params: {LAYERS: 'nasa:bluemarble', TILED: true}
             })
           })
         ],

--- a/src/fr/layers/wms.md
+++ b/src/fr/layers/wms.md
@@ -34,8 +34,8 @@ Jetez un oeil au code suivant:
           new ol.layer.Tile({
             title: 'Global Imagery',
             source: new ol.source.TileWMS({
-              url: 'http://demo.opengeo.org/geoserver/wms',
-              params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+              url: 'https://ahocevar.com/geoserver/wms',
+              params: {LAYERS: 'nasa:bluemarble', TILED: true}
             })
           })
         ],
@@ -69,15 +69,15 @@ Dans OpenLayers, il y a une séparation entre les couches et les sources alors q
 ## Le constructeur `ol.source.TileWMS`
 
 Le constructeur `ol.source.TileWMS` est un argument unique qui est définit par: http://openlayers.org/en/master/apidoc/ol.source.TileWMS.html.
-L'url est la `online resource` du service WMS, et `params` est un objet litéral avec les noms des paramètres et leurs valeurs. Depuis que la version par défaut du WMS est la version 1.3.0 dans OpenLayers, vous pourriez avoir besoin de renseigner une version inférieure dans les `params` si votre WMS ne supporte par le WMS 1.3.0.
+L'url est la `online resource` du service WMS, et `params` est un objet litéral avec les noms des paramètres et leurs valeurs. Seul le paramètre `LAYERS` est requis. Dans cet exemple, nous ajoutons `TILED: true`, une extension spécifique à GeoServer pour une meilleure mise en cache des couches WMS en mosaïque.
 
 ```js
   layers: [
     new ol.layer.Tile({
       title: 'Global Imagery',
       source: new ol.source.TileWMS({
-        url: 'http://demo.opengeo.org/geoserver/wms',
-        params: {LAYERS: 'nasa:bluemarble', VERSION: '1.1.1'}
+        url: 'https://ahocevar.com/geoserver/wms',
+        params: {LAYERS: 'nasa:bluemarble', TILED: true}
       })
     })
   ]
@@ -93,8 +93,8 @@ L'url est la `online resource` du service WMS, et `params` est un objet litéral
     new ol.layer.Tile({
       title: 'Global Imagery',
       source: new ol.source.TileWMS({
-        url: 'http://demo.opengeo.org/geoserver/wms',
-        params: {LAYERS: 'ne:NE1_HR_LC_SR_W_DR', VERSION: '1.1.1'}
+        url: 'https://ahocevar.com/geoserver/wms',
+        params: {LAYERS: 'ne:NE1_HR_LC_SR_W_DR', TILED: true}
       })
     })
   ```


### PR DESCRIPTION
Since demo.opengeo.org is often down, this pull request proposes to use a GeoServer which should be more reliable. Note that I removed the `VERSION: '1.1.1'` param, since every WMS should be supporting 1.3.0 by now. Instead, I added a `TILED: true` param, to make use of GeoServers integrated GeoWebCache.