### PR TITLE
Move config to root of book

### DIFF
--- a/doc/book.json
+++ b/doc/book.json
@@ -1,7 +1,7 @@
 {
-  "honkit": "^3.6.20",
+  "honkit": "^3.7.1",
   "variables": {
-    "workshopUrl": "http://localhost:1234"
+    "workshopUrl": "http://localhost:3000"
   },
   "links": {
     "sidebar": {


### PR DESCRIPTION
It was a mistake in #136 to delete instead of move the `book.json`.

Fixes #141.